### PR TITLE
chore: prepare v1.4.0 for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        pythonversion: ['3.6', '3.8', '3.8', '3.9', 'pypy-3.6']
+        pythonversion: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: set up python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,20 +1,29 @@
 ChangeLog
 =========
 
+1.4.0
+-----
+
+- Adds proper support for `ecdsa-sha2-nistp384`
+
 1.3.3
 -----
+
 - Fix RtD link issue
 
 1.3.2
 -----
+
 - Fix PyPI project URLs
 
 1.3.1
 -----
+
 - Fix `setup.py` issues
 
 1.3.0
 -----
+
 - Can now parse ECDSA keys (if they're signed with an RSA CA)
 - Add `.from_file` constructor on `SSHCertificate`
 - Add a bunch of type hints
@@ -22,6 +31,7 @@ ChangeLog
 
 1.2.0
 -----
+
 - Can now parse DSA and Ed25519 keys (although they still have to have been signed by an RSA CA)
 - Unit tests
 - `key_type` is now in the `SSHCertificate` object
@@ -30,4 +40,5 @@ ChangeLog
 
 1.1.0
 -----
+
 - CA certificate fingerprint (equivalent to `ssh-keygen -l -f /path/to/key.pub`) is now parsed for ssh-rsa CAs. I don't have any ECDSA/Ed25519 CAs so I haven't tested them!

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,25 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 setup(
     name="ssh_certificate_parser",
-    version="1.3.3",
+    version="1.4.0",
     author="James Brown",
     author_email="jbrown@easypost.com",
     url="https://github.com/easypost/ssh_certificate_parser",
     license="ISC",
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=["tests"]),
     description="Python library for interacting with OpenSSH Certificates",
-    long_description=open('README.md', 'r').read(),
-    long_description_content_type='text/markdown',
+    long_description=open("README.md", "r").read(),
+    long_description_content_type="text/markdown",
     install_requires=[
-        'attrs>=16',
+        "attrs>=16",
     ],
     project_urls={
-        'Docs': 'https://ssh-certificate-parser.readthedocs.io/',
-        'Tracker': 'https://github.com/EasyPost/ssh_certificate_parser/issues',
-        'Source': 'https://github.com/EasyPost/ssh_certificate_parser',
+        "Docs": "https://ssh-certificate-parser.readthedocs.io/",
+        "Tracker": "https://github.com/EasyPost/ssh_certificate_parser/issues",
+        "Source": "https://github.com/EasyPost/ssh_certificate_parser",
     },
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -30,8 +29,10 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: POSIX",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: ISC License (ISCL)",
-    ]
+    ],
 )

--- a/ssh_certificate_parser/__init__.py
+++ b/ssh_certificate_parser/__init__.py
@@ -1,22 +1,18 @@
 import base64
-import hashlib
-import enum
 import datetime
-from typing import List
+import enum
+import hashlib
 from pathlib import Path
+from typing import List
 
 import attr
 
-from .errors import UnsupportedKeyTypeError
-from .errors import UnsupportedCertificateTypeError
-from .parser_helpers import take_u32
-from .parser_helpers import take_u64
-from .parser_helpers import take_pascal_bytestring
-from .parser_helpers import take_pascal_string
-from .parser_helpers import take_list
+from .errors import UnsupportedCertificateTypeError, UnsupportedKeyTypeError
+from .parser_helpers import (take_list, take_pascal_bytestring,
+                             take_pascal_string, take_u32, take_u64)
 
 __author__ = 'EasyPost <oss@easypost.com>'
-version_info = (1, 3, 3)
+version_info = (1, 4, 0)
 __version__ = '.'.join(str(s) for s in version_info)
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
-pytest==6.*
+flake8==3.9.*
+importlib_metadata<5
 pytest-cov==2.*
 pytest-mock==3.*
-flake8==3.8.*
+pytest==6.*


### PR DESCRIPTION
Prepares v1.4.0 for release.

Also tests against 3.7 which was missing and 3.10 & 3.11

Addresses #8