### PR TITLE
Handle ed25519-signed certs

### DIFF
--- a/ssh_certificate_parser/__init__.py
+++ b/ssh_certificate_parser/__init__.py
@@ -48,6 +48,10 @@ def take_rsa_cert(raw_pubkey, byte_array):
     return RSAPublicKey(modulus=modulus, exponent=exponent, raw=raw_pubkey)
 
 
+def take_ed25519_cert(raw_pubkey, byte_array):
+    return PublicKey(raw=raw_pubkey)
+
+
 def utcnow():
     return datetime.datetime.utcnow()  # pragma: no cover
 
@@ -152,6 +156,8 @@ class SSHCertificate(object):
         ca_cert_type, raw_ca_rest = take_pascal_string(raw_ca)
         if ca_cert_type in ('ssh-rsa', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384'):
             ca_cert = take_rsa_cert(raw_ca, raw_ca_rest)
+        elif ca_cert_type == 'ssh-ed25519'
+            ca_cert = take_ed25519_cert(raw_ca, raw_ca_rest)
         else:
             raise UnsupportedCertificateTypeError(ca_cert_type)
         signature = blob

--- a/ssh_certificate_parser/__init__.py
+++ b/ssh_certificate_parser/__init__.py
@@ -48,7 +48,7 @@ def take_rsa_cert(raw_pubkey, byte_array):
     return RSAPublicKey(modulus=modulus, exponent=exponent, raw=raw_pubkey)
 
 
-def take_ed25519_cert(raw_pubkey, byte_array):
+def take_ed25519_cert(raw_pubkey):
     return PublicKey(raw=raw_pubkey)
 
 
@@ -157,7 +157,7 @@ class SSHCertificate(object):
         if ca_cert_type in ('ssh-rsa', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384'):
             ca_cert = take_rsa_cert(raw_ca, raw_ca_rest)
         elif ca_cert_type == 'ssh-ed25519'
-            ca_cert = take_ed25519_cert(raw_ca, raw_ca_rest)
+            ca_cert = take_ed25519_cert(raw_ca)
         else:
             raise UnsupportedCertificateTypeError(ca_cert_type)
         signature = blob

--- a/ssh_certificate_parser/__init__.py
+++ b/ssh_certificate_parser/__init__.py
@@ -156,7 +156,7 @@ class SSHCertificate(object):
         ca_cert_type, raw_ca_rest = take_pascal_string(raw_ca)
         if ca_cert_type in ('ssh-rsa', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384'):
             ca_cert = take_rsa_cert(raw_ca, raw_ca_rest)
-        elif ca_cert_type == 'ssh-ed25519'
+        elif ca_cert_type == 'ssh-ed25519':
             ca_cert = take_ed25519_cert(raw_ca)
         else:
             raise UnsupportedCertificateTypeError(ca_cert_type)


### PR DESCRIPTION
SSH certkeys documented [here](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD)

Fairly simple change to handle ed25519-signed certs

FWIW I tested with these sample certs that I generated:

```
ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAINWua0JFZO6YYIkIyHhizDtOYPhn99LXhdN5nL8htFJhAAAAIPFEv9Em3g4hMoeSmXmpxoPz7tRn/8QALAyckJN0CX4IAAAAAAAAAAAAAAABAAAAD215LWVkMjU1MTktY2VydAAAAAAAAAAAAAAAAP//////////AAAAQQAAAA5zb3VyY2UtYWRkcmVzcwAAACsAAAAnMTMyLjIzNC4wLjAvMTYsMTAuMC4wLjAvOCwxNzIuMTcuMC4wLzE2AAAAEgAAAApwZXJtaXQtcHR5AAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIONXf2h3dCB6IrHdErUD+WFveNqj+YTkvEziIsO8egHDAAAAUwAAAAtzc2gtZWQyNTUxOQAAAEC6jsv03nKH9rY7QGZbKKCHh/+rmhc4gUUvoeyI8ubpcGKf2nLr734egiYWKi1lnmxpxEBmNnH3dBQ/sNPudoQA
```

```
ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgdoOROkL5kfIytAjnaGhqVVWN03+uETQDk6yyTVScNEoAAAADAQABAAABgQCp4wxYbVoaT9Iek7fsheMmy5m8RiEtpnyFYdy29wk/yzRWRGrON+tMjaE8vjTFK8AEn79GK+frZptnQKMj5tHeb9gkPvqp2X7ZkLvX5nwEyOBlcN7OJsngJheMa5yI7xa9vI10rXEFsU04thiNNEVc8frUCoFxSYlPhWTHf9ietFeuelcVTgvoGmbeX6fCsM3fyJ3kaviyH+n4k2Vpk93Ee0JAk6HxdOpAmMKEwNZhhL78e03ViTJLyoeQphTcTWzily+tPKxWGS8yQMCmfofePwEzDGN3qXb3M3waT9BC23f7Ck0zf/RIUWz/4zZbMGrmXVg1XlstojtVZgFVOrLlhwRSNSekwPVyNv75/Ubk5wfClx6Ke7qoATC0S0znWhF9s+rYcJREWRi3dh3dvDjStR0qCrKCCWzenz8kKcEOZjHOA+sLuLEafvhPj+RBMaZNh73UqbzwG9fIpvcQER0H9b2IbXKt8x1QgpBsBPO9AWBTLawln5w8YARGeFx8F0cAAAAAAAAAAAAAAAEAAAALbXktcnNhLWNlcnQAAAAAAAAAAAAAAAD//////////wAAAEEAAAAOc291cmNlLWFkZHJlc3MAAAArAAAAJzEzMi4yMzQuMC4wLzE2LDEwLjAuMC4wLzgsMTcyLjE3LjAuMC8xNgAAABIAAAAKcGVybWl0LXB0eQAAAAAAAAAAAAABlwAAAAdzc2gtcnNhAAAAAwEAAQAAAYEAuCYXlFa++6BWg/vFr2fX14+n9kOioE4xwR6tFXHGgFVp5ssHlq9/R+z7FiUZg3twkpS7/8Ggn2eKsaqperfOCngMQrgYffizGKtc5BibduZpY/2wyYCf30gCZrCc1b976Z1CWLT0/2F0srD5spToAuVZ1s49jU8PG8z5xc4TlsoX2ACoxHG6zodR3qSX5CwgdF3sl9ThcW7zQbAvDqte/sAPIPktU/plMkCtcVax+BgQXDg4Gz5n7jOZA/ojsY/GFacfz5JePcugfnrK36FHBkwI90UrueV+XRHqErgKFjFZtk7b1SOpC3wic4hjX4ymret1X+8Zu+0btNCR2Ea+TWH1pkjxlcETrwqjzP6eA0Azh/d5do/EUq80rw5jh874JaD1HWDp2tAqRuFPkkW7SaZmheMH1yKhVweg8Vv69Xwh+F1KnWAlCjDm5zWtPdrKWEFK15f2kFIhVdI8WEvxLoB1/JsBVNtczrATtKWqVqEIcJQngzzuS4u09P+kkAxbAAABlAAAAAxyc2Etc2hhMi01MTIAAAGAU20AA+ENAAoOpNqiSimUJH+yVacVV9/IHM9LnuRyhH/NsyK985EUQkLKb+bczgAI3mw6hyMIkHSf5nr2ROAxXwJ2mIVrGOIEFdbSvgeRi2bekIu53C+gbkpqlGVk9bfTl145m8yHFOsAZdP++aNA7b3KiLJHeFsPV4O32N3C66ftpzBuG9qg0Cm3XcWeOgVGcmu3TBPquLhfS5O8ciuSe3IOD0mvlPlCSi87AKUlW0NMPQAdNnQ5ImJP8y4nct3i0+dC7TB5vggeIkTgDC2vdGj3+BoZTiwtnbyaHcSNBSG7wlre+cFubmmm02vqEgmIU0F2qXFTWCV/krcHXz8zpSMPA5w+d4ouiZppL2BZWPQgEywVsVKX41QwaAKQO/8qfbqNAustlv/exzwt5AcCsnaffJCc3m46l6qayvHS1OyKPS4cc+isMT9p1Pq2xXFvXjuhHnhfmna/9Bkk5q6vYWXyki7aTmsTRkU/28nla04vH2kz9tzA2FlWGaU0Fcze
```